### PR TITLE
25 get packageid

### DIFF
--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageIdController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageIdController.java
@@ -1,15 +1,13 @@
 package com.spring_rest_api.api_paths;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.google.cloud.firestore.*;
-import com.google.cloud.firestore.CollectionReference;
-import com.google.cloud.firestore.Firestore;
-import com.google.firebase.cloud.FirestoreClient;
-import com.google.api.core.ApiFuture;
-
+import com.spring_rest_api.api_paths.service.PackageIdService;
 
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,30 +17,17 @@ import java.util.concurrent.ExecutionException;
 
 @RestController
 public class PackageIdController {
+
+    @Autowired
+    PackageIdService packageIdService;
     
 	@GetMapping("/package/{id}")
-	public String packageId(@PathVariable String id) throws ExecutionException, InterruptedException {
-        String collection = "Packages";
-        Firestore db = FirestoreClient.getFirestore();
-        CollectionReference cR = db.collection(collection);
-        DocumentReference docRef = cR.document(id);
-        ApiFuture<DocumentSnapshot> future = docRef.get();
-        DocumentSnapshot document = future.get();
+	public ResponseEntity<String> packageId(@PathVariable String id) throws ExecutionException, InterruptedException {
+        String document_string = packageIdService.getPackage(id);
+        HttpStatus status = (document_string == "Package does not exist.") ? 
+            HttpStatus.NOT_FOUND : HttpStatus.OK;
 
-        return document.getData().toString();
-
-        // // List<ApiFuture<QuerySnapshot>> futures = new ArrayList<>();
-        // Query query = cR.whereEqualTo("ID", id);
-
-        // ApiFuture<QuerySnapshot> querySnapshot = query.get();
-
-        // System.out.println("QuerySnapshot: " + querySnapshot.get().getDocuments().size());
-
-        // for (DocumentSnapshot document : querySnapshot.get().getDocuments()) {
-        //     System.out.println(document.getId());
-        // }
-
-		// return String.format("PackageId %s!", id);        
+        return ResponseEntity.status(status).body(document_string);
 	}
 
     @PutMapping("/package/{id}")

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageIdController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageIdController.java
@@ -3,16 +3,46 @@ package com.spring_rest_api.api_paths;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.google.cloud.firestore.*;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.firebase.cloud.FirestoreClient;
+import com.google.api.core.ApiFuture;
+
+
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.concurrent.ExecutionException;
 
 
 @RestController
 public class PackageIdController {
     
 	@GetMapping("/package/{id}")
-	public String packageId(@PathVariable String id) {
-		return String.format("PackageId %s!", id);
+	public String packageId(@PathVariable String id) throws ExecutionException, InterruptedException {
+        String collection = "Packages";
+        Firestore db = FirestoreClient.getFirestore();
+        CollectionReference cR = db.collection(collection);
+        DocumentReference docRef = cR.document(id);
+        ApiFuture<DocumentSnapshot> future = docRef.get();
+        DocumentSnapshot document = future.get();
+
+        return document.getData().toString();
+
+        // // List<ApiFuture<QuerySnapshot>> futures = new ArrayList<>();
+        // Query query = cR.whereEqualTo("ID", id);
+
+        // ApiFuture<QuerySnapshot> querySnapshot = query.get();
+
+        // System.out.println("QuerySnapshot: " + querySnapshot.get().getDocuments().size());
+
+        // for (DocumentSnapshot document : querySnapshot.get().getDocuments()) {
+        //     System.out.println(document.getId());
+        // }
+
+		// return String.format("PackageId %s!", id);        
 	}
 
     @PutMapping("/package/{id}")

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/service/PackageIdService.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/service/PackageIdService.java
@@ -1,0 +1,30 @@
+package com.spring_rest_api.api_paths.service;
+
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.stereotype.Service;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.firebase.cloud.FirestoreClient;
+
+@Service
+public class PackageIdService {
+    private static final String COLLECTION_NAME = "Packages";
+
+    // Returns a String representation of the document found in Packages
+    public String getPackage(String id) throws ExecutionException, InterruptedException{
+        Firestore db = FirestoreClient.getFirestore();
+        CollectionReference cR = db.collection(COLLECTION_NAME);
+        DocumentReference docRef = cR.document(id);
+        ApiFuture<DocumentSnapshot> future = docRef.get();
+        DocumentSnapshot document = future.get();
+
+        return (document.exists()) ? document.getData().toString() : "Package does not exist.";
+    }
+
+}


### PR DESCRIPTION
This should take care of the GET request for package/{id} api request. 

It also account for 404 error.

The service can also be reused in the package/{id}/rate as well.