### PR TITLE
27 get packageidrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 ### VS Code ###
 **/.vscode/
+
+## Account Key ##
+**/serviceAccountKey.json

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/ApiPathsApplication.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/ApiPathsApplication.java
@@ -7,12 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 @SpringBootApplication
 @RestController
 public class ApiPathsApplication {
-
-  
     public static void main(String[] args) {
       SpringApplication.run(ApiPathsApplication.class, args);
     }
-
-
-
 }

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/RaterController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/RaterController.java
@@ -17,6 +17,7 @@ import com.spring_rest_api.api_paths.service.PackageIdService;
 import com.spring_rest_api.cli.NetScoreMetric;
 import com.spring_rest_api.cli.NetScoreUtil;
 
+
 @RestController
 public class RaterController {
     private final Logger logger;
@@ -28,7 +29,7 @@ public class RaterController {
         this.logger = LoggerFactory.getLogger(this.getClass());
     }
     
-    @GetMapping("/package/{id}/rate")
+    @GetMapping(value="/package/{id}/rate", produces="application/json")
     public ResponseEntity<Object> PackageRate(@PathVariable String id) {
         Map<String, Object> packageData = null;
 
@@ -39,12 +40,12 @@ public class RaterController {
         }
         
         if (packageData == null) {
-            String resultMessage = String.format("Could not find package with id = \"%s\"", id);
+            String resultMessage = String.format("Could not find package data associated with id = \"%s\"", id);
             this.logger.info(resultMessage);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Package does not exist.");
         }
-
-        String packageUrl = (String) ((Map<String, Object>) packageData.get("data")).get("URL");
+        
+        String packageUrl = (String) packageData.get("URL");
 
         if (packageUrl == null) {
             String resultMessage = String.format("Package with id = \"%s\" did not have a URL", id);
@@ -52,7 +53,7 @@ public class RaterController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The package rating system choked on at least one of the metrics.");
         }
         
-        NetScoreMetric nsm = NetScoreUtil.CalculateNetScore(packageUrl);
+        NetScoreMetric nsm = NetScoreUtil.GetNetScore(packageUrl);
         
         if (nsm == null) {
             String resultMessage = String.format("Package with id = \"%s\" and URL = \"%s\" returned a null NetScoreMetric", id, packageUrl);
@@ -60,7 +61,7 @@ public class RaterController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("The package rating system choked on at least one of the metrics.");
         }
 
-        return ResponseEntity.status(HttpStatus.OK).body(nsm);
+        return new ResponseEntity<Object>(nsm, null, HttpStatus.OK);
     }
     
 

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/service/PackageIdService.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/service/PackageIdService.java
@@ -3,6 +3,9 @@ package com.spring_rest_api.api_paths.service;
 import com.spring_rest_api.api_paths.entity.Product;
 
 import java.util.concurrent.ExecutionException;
+
+import javax.annotation.Nonnull;
+
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -23,7 +26,7 @@ public class PackageIdService {
 
     // Returns a String representation of the document found in Packages
     // Returns null if the document can't be found
-    public String getPackage(String id) throws ExecutionException, InterruptedException{
+    public String getPackage(@Nonnull String id) throws ExecutionException, InterruptedException{
         DocumentReference docRef = collectionReference.document(id);
         ApiFuture<DocumentSnapshot> future = docRef.get();
         DocumentSnapshot document = future.get();
@@ -33,15 +36,30 @@ public class PackageIdService {
 
     // Returns null if the document can't be found
     public Map<String, Object> getPackageData(String id) throws ExecutionException, InterruptedException{
+        if (id == null) {
+            return null;
+        }
+        
         DocumentReference docRef = collectionReference.document(id);
         ApiFuture<DocumentSnapshot> future = docRef.get();
         DocumentSnapshot document = future.get();
-        return document.getData();
+
+        Map<String, Object> product = document.getData();
+        if (product == null) {
+            return null;
+        }
+
+        Object dataObject = product.get("data");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dataMap = (Map<String, Object>) dataObject;
+        
+        return dataMap;
     }
 
 
     // Returns true if document found has been deleted from Packages collection
-    public boolean deletePackage(String id) throws ExecutionException, InterruptedException {
+    public boolean deletePackage(@Nonnull String id) throws ExecutionException, InterruptedException {
         DocumentReference docRef = collectionReference.document(id);
         DocumentSnapshot document = docRef.get().get();
         if (!document.exists()) {return false;}

--- a/api_paths/src/main/java/com/spring_rest_api/cli/NetScoreUtil.java
+++ b/api_paths/src/main/java/com/spring_rest_api/cli/NetScoreUtil.java
@@ -3,13 +3,31 @@ package com.spring_rest_api.cli;
 public class NetScoreUtil {
     static { System.loadLibrary("NetScoreUtil"); }
     
-    public static native NetScoreMetric CalculateNetScore(String url);
+    private static native NetScoreMetric CalculateNetScore(String url);
     
+    public static NetScoreMetric GetNetScore(String url) {
+        // Null check
+        if (url == null) {
+            return null;
+        }
+
+        // Call the C++ library
+        NetScoreMetric nsm = CalculateNetScore(url);
+
+        // Null check
+        if (nsm == null) {
+            return null;
+        }
+        
+        // Something about instantiating this in C++ breaks the object a bit. This fixes that.
+        return new NetScoreMetric(nsm.License, nsm.Correctness, nsm.BusFactor, nsm.RampUp, nsm.ResponsiveMaintainer, nsm.NetScore);
+    }
+
     public static NetScoreMetric[] test() {
         // this github
-        NetScoreMetric nsm1 = CalculateNetScore("https://github.com/Alethon/ECE461_Part2");
+        NetScoreMetric nsm1 = GetNetScore("https://github.com/Alethon/ECE461_Part2");
         // a string that should fail
-        NetScoreMetric nsm2 = CalculateNetScore("athihgagg");
+        NetScoreMetric nsm2 = GetNetScore("athihgagg");
         return new NetScoreMetric[] { nsm1, nsm2 };
     }
 }


### PR DESCRIPTION
Direct calls to Gson.toJson should be eliminated, the issue was that the `Content-Type` header wasn't being changed to `application/json`. Annotations for other mappings that return json objects should be updated to include `produces="application/json"`, as can be seen on line 32 of RaterController.java. This will lead the returned object to be automatically converted to json without Gson.toJson calls.