### PR TITLE
GET byName returns "application/json"

### DIFF
--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/AuthenticateController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/AuthenticateController.java
@@ -37,7 +37,7 @@ public class AuthenticateController {
        
     }
 
-    @PutMapping("/authenticate")
+    @PutMapping(value = "/authenticate", produces = "application/json")
     public ResponseEntity<?> authenticate(@RequestBody AuthenticationRequest request) {
         logger.info("User: {}", request.getUser());
         logger.info("Secret: {}", request.getSecret());

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageByNameController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageByNameController.java
@@ -26,7 +26,7 @@ public class PackageByNameController {
     @Autowired
     AuthenticateService authenticateService;
     
-	@GetMapping("/package/byName/{name}")
+	@GetMapping(value="/package/byName/{name}", produces = "application/json")
 	public ResponseEntity<String> packageByName(@PathVariable String name , @RequestHeader("X-Authorization") String token) throws ExecutionException, InterruptedException {
         if (!validateToken(token)) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
@@ -38,7 +38,7 @@ public class PackageByNameController {
         return (result == null) ? notFoundError : ResponseEntity.ok().body(result);
 	}
 
-    @DeleteMapping("/package/byName/{name}")
+    @DeleteMapping(value = "/package/byName/{name}")
     public ResponseEntity<String> deleteMethodName(@PathVariable String name , @RequestHeader("X-Authorization") String token) throws ExecutionException, InterruptedException {
         if (!validateToken(token)) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageByRegexController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageByRegexController.java
@@ -26,7 +26,7 @@ public class PackageByRegexController {
     @Autowired
     RegexService regexService;
 
-    @PostMapping("/package/byRegEx")
+    @PostMapping(value = "/package/byRegEx", produces = "application/json")
     public ResponseEntity<String> postMethodName(@RequestBody RegexSchema regexSchema,
             @RequestHeader("X-Authorization") String token) throws ExecutionException, InterruptedException {
         if (!validateToken(token)) {

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageIdController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/PackageIdController.java
@@ -37,7 +37,7 @@ public class PackageIdController {
     @Autowired
     AuthenticateService authenticateService;
 
-    @GetMapping("/package/{id}")
+    @GetMapping(value = "/package/{id}", produces = "application/json")
     public ResponseEntity<String> packageId(@PathVariable String id ,  @RequestHeader("X-Authorization") String token) throws ExecutionException, InterruptedException {
         if (!validateToken(token)) {
             logger.info("Token sent by User: {}", token);

--- a/api_paths/src/main/java/com/spring_rest_api/api_paths/PackagesPostController.java
+++ b/api_paths/src/main/java/com/spring_rest_api/api_paths/PackagesPostController.java
@@ -30,7 +30,7 @@ public class PackagesPostController {
         System.out.println("Packages!");
     }
 
-    @PostMapping("/package")
+    @PostMapping(value = "/package", produces = "application/json")
     public ResponseEntity<String> package_single(@RequestBody Product product) throws ExecutionException, InterruptedException {
         //packageService.savePackage(product);
         return ResponseEntity.status(HttpStatus.CREATED).body(packageService.savePackage(product));


### PR DESCRIPTION
The old api endpoints would return a JSON formatted string, however they would look like the image below.
![image](https://user-images.githubusercontent.com/70293835/235375312-c054cc46-4f15-4771-bd9b-1e879f88cfed.png)

The new way will make the output look like this. Which is also the way on the swagger document as well as make front end parsing easier.
![image](https://user-images.githubusercontent.com/70293835/235375338-066eb4cb-b6df-41a0-acdd-1e8f824e667a.png)
